### PR TITLE
Force WLAN_AKM_SUITE_SAE in big endian in NL80211_CMD_EXTERNAL_AUTH with nl80211 wifi

### DIFF
--- a/drivers/unisoc_platform/wlan/common/cfg80211.c
+++ b/drivers/unisoc_platform/wlan/common/cfg80211.c
@@ -842,7 +842,8 @@ int sprd_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
 			goto err;
 	}
 
-	con.wpa_versions = sprd_convert_wpa_version(sme->crypto.wpa_versions);
+	con.wpa_versions = sprd_convert_wpa_version(sme->crypto.wpa_versions,
+			sme->crypto.akm_suites[0]);
 	netdev_info(ndev, "sme->wpa versions %#x, con.wpa_version:%#x\n",
 		    sme->crypto.wpa_versions, con.wpa_versions);
 	netdev_info(ndev, "management frame protection %#x\n", sme->mfp);

--- a/drivers/unisoc_platform/wlan/common/cfg80211.h
+++ b/drivers/unisoc_platform/wlan/common/cfg80211.h
@@ -278,7 +278,8 @@ struct sprd_ieee80211_regdomain {
 	struct sprd_reg_rule reg_rules[];
 };
 
-static inline __le32 sprd_convert_wpa_version(u32 version)
+static inline __le32 sprd_convert_wpa_version(u32 version,
+		u32 akm)
 {
 	u32 ret;
 
@@ -287,7 +288,10 @@ static inline __le32 sprd_convert_wpa_version(u32 version)
 		ret = SPRD_WPA_VERSION_1;
 		break;
 	case NL80211_WPA_VERSION_2:
-		ret = SPRD_WPA_VERSION_2;
+		if (akm == WLAN_AKM_SUITE_SAE)
+			ret = SPRD_WPA_VERSION_3;
+		else
+			ret = SPRD_WPA_VERSION_2;
 		break;
 	case NL80211_WPA_VERSION_3:
 		ret = SPRD_WPA_VERSION_3;

--- a/net/wireless/nl80211.c
+++ b/net/wireless/nl80211.c
@@ -16969,9 +16969,26 @@ int cfg80211_external_auth_request(struct net_device *dev,
 	if (!hdr)
 		goto nla_put_failure;
 
+	/* Some historical mistakes in drivers <-> userspace interface (notably
+	 * between drivers and wpa_supplicant) led to a big-endian conversion
+	 * being needed on NL80211_ATTR_AKM_SUITES _only_ when its value is
+	 * WLAN_AKM_SUITE_SAE. This is now fixed on userspace side, but for the
+	 * benefit of older wpa_supplicant versions, send this particular value
+	 * in big-endian. Note that newer wpa_supplicant will also detect this
+	 * particular value in big endian still, so it all continues to work.
+	 */
+	if (params->key_mgmt_suite == WLAN_AKM_SUITE_SAE) {
+		if (nla_put_be32(msg, NL80211_ATTR_AKM_SUITES,
+				 cpu_to_be32(WLAN_AKM_SUITE_SAE)))
+			goto nla_put_failure;
+	} else {
+		if (nla_put_u32(msg, NL80211_ATTR_AKM_SUITES,
+				params->key_mgmt_suite))
+			goto nla_put_failure;
+	}
+
 	if (nla_put_u32(msg, NL80211_ATTR_WIPHY, rdev->wiphy_idx) ||
 	    nla_put_u32(msg, NL80211_ATTR_IFINDEX, dev->ifindex) ||
-	    nla_put_u32(msg, NL80211_ATTR_AKM_SUITES, params->key_mgmt_suite) ||
 	    nla_put_u32(msg, NL80211_ATTR_EXTERNAL_AUTH_ACTION,
 			params->action) ||
 	    nla_put(msg, NL80211_ATTR_BSSID, ETH_ALEN, params->bssid) ||


### PR DESCRIPTION
Fix SAE use.